### PR TITLE
Add controls for displaying footer page count/pager with custom foote…

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.html
@@ -76,6 +76,8 @@
     [selectedCount]="selected.length"
     [selectedMessage]="!!selectionType && messages.selectedMessage"
     [pagerNextIcon]="cssClasses.pagerNext"
+    [displayPageCount]="displayPageCount"
+    [displayPager]="displayPager"
     (page)="onFooterPage($event)"
   >
   </datatable-footer>

--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -413,6 +413,16 @@ export class DatatableComponent implements OnInit, OnDestroy, DoCheck, AfterView
   @Input() summaryPosition: string = 'top';
 
   /**
+   * A flag to hide / show page count in footer
+   */
+  @Input() displayPageCount: boolean = true;
+
+  /**
+   * A flag to hide / show pager in footer
+   */
+  @Input() displayPager: boolean = true;
+
+  /**
    * Body was scrolled typically in a `scrollbarV:true` scenario.
    */
   @Output() scroll: EventEmitter<any> = new EventEmitter();

--- a/projects/swimlane/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -8,6 +8,10 @@ import { DatatableFooterDirective } from './footer.directive';
       [ngClass]="{ 'selected-count': selectedMessage }"
       [style.height.px]="footerHeight"
     >
+      <div class="page-count" *ngIf="displayPageCount">
+        <span *ngIf="selectedMessage"> {{ selectedCount?.toLocaleString() }} {{ selectedMessage }} / </span>
+        {{ rowCount?.toLocaleString() }} {{ totalMessage }}
+      </div>
       <ng-template
         *ngIf="footerTemplate"
         [ngTemplateOutlet]="footerTemplate.template"
@@ -20,12 +24,8 @@ import { DatatableFooterDirective } from './footer.directive';
         }"
       >
       </ng-template>
-      <div class="page-count" *ngIf="!footerTemplate">
-        <span *ngIf="selectedMessage"> {{ selectedCount?.toLocaleString() }} {{ selectedMessage }} / </span>
-        {{ rowCount?.toLocaleString() }} {{ totalMessage }}
-      </div>
       <datatable-pager
-        *ngIf="!footerTemplate"
+        *ngIf="displayPager"
         [pagerLeftArrowIcon]="pagerLeftArrowIcon"
         [pagerRightArrowIcon]="pagerRightArrowIcon"
         [pagerPreviousIcon]="pagerPreviousIcon"
@@ -45,6 +45,8 @@ import { DatatableFooterDirective } from './footer.directive';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataTableFooterComponent {
+  @Input() displayPageCount: boolean;
+  @Input() displayPager: boolean;
   @Input() footerHeight: number;
   @Input() rowCount: number;
   @Input() pageSize: number;


### PR DESCRIPTION
…r template

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Passing in a footer template will automatically remove the row count and pager from the datatable footer. 

**What is the new behavior?**
Passing in a footer template will display the template between the row count and pager by default, with the option to hide one or both.

**Other information**:
Existing implementations that rely on row count/pager not displaying when a custom template is used will need to set `displayPageCount` and `displayPager` to `false`.