### PR TITLE
Reset offsetX after column resize

### DIFF
--- a/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/components/datatable.component.ts
@@ -43,7 +43,7 @@ import { ScrollbarHelper } from '../services/scrollbar-helper.service';
 import { ColumnChangesService } from '../services/column-changes.service';
 import { DimensionsHelper } from '../services/dimensions-helper.service';
 import { throttleable } from '../utils/throttle';
-import { forceFillColumnWidths, adjustColumnWidths } from '../utils/math';
+import { forceFillColumnWidths, adjustColumnWidths, getContentWidth } from '../utils/math';
 import { sortRows } from '../utils/sort';
 
 @Component({
@@ -1006,10 +1006,27 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
     this.recalculateColumns(cols, idx);
     this._internalColumns = cols;
 
+    this.resetOffsetX();
+
     this.resize.emit({
       column,
       newValue
     });
+  }
+
+  resetOffsetX(columns: any = this._internalColumns) {
+    let windowWidth = this._innerWidth;
+    if (this.scrollbarV) {
+      windowWidth = windowWidth - this.scrollbarHelper.width;
+    }
+
+    let rowWidth = getContentWidth(columns);
+
+    const maxOffsetX = rowWidth - windowWidth;
+
+    if (this._offsetX.value > maxOffsetX) {
+      this._offsetX.next(maxOffsetX);
+    }
   }
 
   /**

--- a/projects/swimlane/ngx-datatable/src/lib/utils/math.ts
+++ b/projects/swimlane/ngx-datatable/src/lib/utils/math.ts
@@ -156,7 +156,7 @@ function removeProcessedColumns(columnsToResize: any[], columnsProcessed: any[])
 /**
  * Gets the width of the columns
  */
-function getContentWidth(allColumns: any, defaultColWidth: number = 300): number {
+export function getContentWidth(allColumns: any, defaultColWidth: number = 300): number {
   let contentWidth = 0;
 
   for (const column of allColumns) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [X] Bugfix

**What is the current behavior?**

When there is a column with `[frozenRight]=true`, and the datatable is scrolled all the way to the right, a gap appears when you size one of the non-frozen columns down. Scrolling to the left and then back to the right causes the `offsetX` to recalculate and the gap to disappear.

**What is the new behavior?**

When calculating the new column widths after the resize handle is released, the scroll position of the datatable resets to the maximum possible `offsetX`.

**Does this PR introduce a breaking change?**

- [X] No
